### PR TITLE
Fix formatting (max width mapping), bump 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guacamole",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A friendly wrapper for the SauceLabs browser listing API",
   "main": "index.js",
   "directories": {

--- a/src/cli_list.js
+++ b/src/cli_list.js
@@ -15,25 +15,20 @@ module.exports = (callback) => {
 
   const maxCLIWidth = _.max(_.map(_.map(browsers, (b) => b.id), (b) => b.length)) + 5;
 
-  const maxBrowserWidth = _.max(browsers.map(
-    (b) => b.desiredCapabilities.browserName || "Native app"
-  ), (b) => b.length).length + 5;
+  const maxBrowserWidth = _.max(_.map(_.map(browsers,
+    (b) => b.desiredCapabilities.browserName || "Native app"), (b) => b.length)) + 5;
 
   const maxVersionWidth = _.max(browsers.map(
     (b) => b.desiredCapabilities.version || b.desiredCapabilities.platformVersion
   ), (b) => b.toString().length).length + 5;
 
-  const maxOSWidth = _.max(
-    _.map(
-      _.map(browsers, (b) => b.desiredCapabilities.platform || b.desiredCapabilities.platformName),
-      (b) => b.length)
-  ) + 5;
+  const maxOSWidth = _.max(_.map(_.map(browsers, 
+    (b) => b.desiredCapabilities.platform || b.desiredCapabilities.platformName),
+    (b) => b.length)) + 5;
 
-  const maxDeviceWidth = _.max(
-    _.map(
-      _.map(browsers, (b) => b.desiredCapabilities.deviceName || "Desktop"),
-      (b) => b.length)
-  ) + 5;
+  const maxDeviceWidth = _.max(_.map(_.map(browsers, 
+    (b) => b.desiredCapabilities.deviceName || "Desktop"),
+    (b) => b.length)) + 5;
 
   const table = new Table({
     head: ["Family", "Alias", "Browser/Env", "Version", "OS", "Device"],

--- a/src/cli_list.js
+++ b/src/cli_list.js
@@ -22,11 +22,11 @@ module.exports = (callback) => {
     (b) => b.desiredCapabilities.version || b.desiredCapabilities.platformVersion
   ), (b) => b.toString().length).length + 5;
 
-  const maxOSWidth = _.max(_.map(_.map(browsers, 
+  const maxOSWidth = _.max(_.map(_.map(browsers,
     (b) => b.desiredCapabilities.platform || b.desiredCapabilities.platformName),
     (b) => b.length)) + 5;
 
-  const maxDeviceWidth = _.max(_.map(_.map(browsers, 
+  const maxDeviceWidth = _.max(_.map(_.map(browsers,
     (b) => b.desiredCapabilities.deviceName || "Desktop"),
     (b) => b.length)) + 5;
 

--- a/src/cli_list.js
+++ b/src/cli_list.js
@@ -13,7 +13,7 @@ module.exports = (callback) => {
 
   const maxFamWidth = _.max(Object.keys(families), (f) => f.length).length + 5;
 
-  const maxCLIWidth = _.max(_.map(browsers, "id"), (b) => b.length).length + 5;
+  const maxCLIWidth = _.max(_.map(_.map(browsers, (b) => b.id), (b) => b.length)) + 5;
 
   const maxBrowserWidth = _.max(browsers.map(
     (b) => b.desiredCapabilities.browserName || "Native app"
@@ -23,13 +23,17 @@ module.exports = (callback) => {
     (b) => b.desiredCapabilities.version || b.desiredCapabilities.platformVersion
   ), (b) => b.toString().length).length + 5;
 
-  const maxOSWidth = _.max(browsers.map(
-    (b) => b.desiredCapabilities.platform || b.desiredCapabilities.platformName
-  ), (b) => b.toString().length).length + 5;
+  const maxOSWidth = _.max(
+    _.map(
+      _.map(browsers, (b) => b.desiredCapabilities.platform || b.desiredCapabilities.platformName),
+      (b) => b.length)
+  ) + 5;
 
-  const maxDeviceWidth = _.max(_.map(browsers, (b) =>
-    b.desiredCapabilities.deviceName || "Desktop"
-  ), (b) => b.length).length + 5;
+  const maxDeviceWidth = _.max(
+    _.map(
+      _.map(browsers, (b) => b.desiredCapabilities.deviceName || "Desktop"),
+      (b) => b.length)
+  ) + 5;
 
   const table = new Table({
     head: ["Family", "Alias", "Browser/Env", "Version", "OS", "Device"],


### PR DESCRIPTION
Formatting regressed during our recent updates to ES6 and Saucelabs, which made it impossible to grab ids for devices/browsers. This PR fixes the mapping.

/cc @jherr 