### PR TITLE
SauceLabs errs when browserName is not specified for appium emulators

### DIFF
--- a/src/browsers.js
+++ b/src/browsers.js
@@ -357,6 +357,15 @@ const SauceBrowsers = {
           result.deviceName = deviceName;
         }
 
+        // For Appium android, set browserName="Browser"
+        if (result["appium-version"]) {
+          if (result.platformName === 'Android') {
+            result.browserName = "Browser";
+          } else if(result.platformName === 'iOS') {
+            result.browserName = "Safari";
+          }
+        } 
+
         return result;
       }).map((browser) => {
         const result = {

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -359,9 +359,9 @@ const SauceBrowsers = {
 
         // For Appium android, set browserName="Browser"
         if (result["appium-version"]) {
-          if (result.platformName === 'Android') {
+          if (result.platformName === "Android") {
             result.browserName = "Browser";
-          } else if(result.platformName === 'iOS') {
+          } else if (result.platformName === "iOS") {
             result.browserName = "Safari";
           }
         } 

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -348,6 +348,23 @@ const SauceBrowsers = {
             result.platformVersion = browser.short_version || browser.version;
             result.platformName = osName;
           }
+
+          // For Android Emulator, we need to set browserName to either Chrome or Browser depending on version
+          if (deviceName === "Android Emulator" && result.platformVersion) {
+            let version;
+            try {
+              version = parseFloat(result.platformVersion);
+            } catch (e) {
+              throw new Error("Expected platform version to be a number, but was " + result.platformVersion);
+            }
+            if (version) {
+              if (version >= 6.0) {
+                result.browserName = "Chrome";
+              } else {
+                result.browserName = "Browser";
+              }
+            }
+          }
         }
 
         // Note: we only set the device property if we have a non-desktop device. This is because
@@ -356,15 +373,6 @@ const SauceBrowsers = {
           // this is a mobile device as opposed to a desktop browser.
           result.deviceName = deviceName;
         }
-
-        // For Appium android, set browserName="Browser"
-        if (result["appium-version"]) {
-          if (result.platformName === "Android") {
-            result.browserName = "Browser";
-          } else if (result.platformName === "iOS") {
-            result.browserName = "Safari";
-          }
-        } 
 
         return result;
       }).map((browser) => {


### PR DESCRIPTION
Example: https://saucelabs.com/beta/tests/b2d875e434534c6696a8b85d4f1517a0/metadata#0

I think if browserName is not passed in, SauceLabs sets it to "chrome", so maybe I should just open a ticket with saucelabs. Anyways, just opening this PR since we know that the settings returned by guacamole doesn't work for appium android or ios browsers.