### PR TITLE
Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - Appium support for native app `desiredCapabilities` objects
   - Built-in command-line interface for listing browsers and generating `desiredCapabilities` objects.
   - Normalize strings from the SauceLabs browser list API to values that `desiredCapabilities` actually consumes.
+  - Proxy support if `SAUCE_OUTBOUND_PROXY` is set to a proxy address.
 
 ### Installation
 
@@ -363,6 +364,17 @@ Version: 52
 Platform: windows 2008
 > Generating sauce browser id...
 > Use chrome_52_Windows_2008_Desktop as your browser
+```
+
+### Proxy Configuration
+
+To use a proxy to reach Saucelabs when querying the Saucelabs API, `gaucamole` checks the presence of an environment variable called `SAUCE_OUTBOUND_PROXY`. Set this variable before using `gaucamole` on the CLI or programmatically to use a proxy.
+
+Note: Proxy configuration is not supported in **synchronous mode**.
+
+```console
+$ export SAUCE_OUTBOUND_PROXY=http://your-internal-proxy-host:8080
+$ guacamole
 ```
 
 ## Licenses

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -4,7 +4,7 @@
 const Q = require("q");
 const _ = require("lodash");
 
-var request = require("request");
+let request = require("request");
 
 if (process.env.SAUCE_OUTBOUND_PROXY) {
   // NOTE: It doesn't appear that syncRequest supports a proxy setting,

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -3,7 +3,15 @@
 "use strict";
 const Q = require("q");
 const _ = require("lodash");
-const request = require("request");
+
+var request = require("request");
+
+if (process.env.SAUCE_OUTBOUND_PROXY) {
+  // NOTE: It doesn't appear that syncRequest supports a proxy setting,
+  // so only asynchronous access to guacamole will support SAUCE_OUTBOUND_PROXY
+  request = request.defaults(process.env.SAUCE_OUTBOUND_PROXY);
+}
+
 const syncRequest = require("sync-request");
 let browsers = [];
 const latest = {};


### PR DESCRIPTION
This PR adds support for setting a variable called `SAUCE_OUTBOUND_PROXY` to configure an HTTP proxy when contacting the Saucelabs API using `guacamole`.

/cc @archlichking 