### PR TITLE
Turn off strict SSL when requesting saucelabs browser list

### DIFF
--- a/src/browsers.js
+++ b/src/browsers.js
@@ -9,7 +9,10 @@ let request = require("request");
 if (process.env.SAUCE_OUTBOUND_PROXY) {
   // NOTE: It doesn't appear that syncRequest supports a proxy setting,
   // so only asynchronous access to guacamole will support SAUCE_OUTBOUND_PROXY
-  request = request.defaults({proxy: process.env.SAUCE_OUTBOUND_PROXY});
+  request = request.defaults({
+    strictSSL: false,
+    proxy: process.env.SAUCE_OUTBOUND_PROXY
+  });
 }
 
 const syncRequest = require("sync-request");


### PR DESCRIPTION
This PR sets `strictSSL` off.

/cc @archlichking 