### PR TITLE
Add protection from invalid responses #42

### DIFF
--- a/src/browsers.js
+++ b/src/browsers.js
@@ -217,6 +217,9 @@ const SauceBrowsers = {
   },
 
   _normalize: (data) => {
+    if (!Array.isArray(data)) {
+      throw new Error(`Invalid Response: ${data}`);
+    }
     const overallResult = data
       .filter((browser) =>
         browser.automation_backend === "webdriver" || browser.automation_backend === "appium"

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -218,7 +218,7 @@ const SauceBrowsers = {
 
   _normalize: (data) => {
     if (!Array.isArray(data)) {
-      throw new Error(`Invalid Response: ${data}`);
+      throw new Error(`Invalid Response: ${JSON.stringify(data)}`);
     }
     const overallResult = data
       .filter((browser) =>

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -78,4 +78,10 @@ describe("normalizer", () => {
     expect(() => Browsers._normalize(response)).to.throw(`Invalid Response: ${response}`);
   });
 
+  it("handles and logs a non-array, object response", () => {
+    const response = { error: "something went wrong" };
+    const expected = `Invalid Response: ${JSON.stringify(response)}`;
+    expect(() => Browsers._normalize(response)).to.throw(expected);
+  });
+
 });

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -73,4 +73,9 @@ describe("normalizer", () => {
     expect(ipad).to.have.property("deviceOrientation", "landscape");
   });
 
+  it("handles and logs a non-array response", () => {
+    const response = null;
+    expect(() => Browsers._normalize(response)).to.throw(`Invalid Response: ${response}`);
+  });
+
 });


### PR DESCRIPTION
Fixes #42 We're assuming `data` is always an array (because we're using `filter` and `map`). We should validate that assumption and if the response does not meet that expectation, throw a helpful error message.